### PR TITLE
HTTP > HTTPS redirect encoding fix

### DIFF
--- a/http.c
+++ b/http.c
@@ -73,7 +73,7 @@ redirect_reply(BIO *const c, const char *url, const int code)
     memset(safe_url, 0, MAXBUF);
     for(i = j = 0; i < MAXBUF && j < MAXBUF && url[i]; i++)
         if(isalnum(url[i]) || url[i] == '_' || url[i] == '.' || url[i] == ':' || url[i] == '/'
-        || url[i] == '?' || url[i] == '&' || url[i] == ';')
+        || url[i] == '?' || url[i] == '&' || url[i] == ';' || url[i] == '=')
             safe_url[j++] = url[i];
         else {
             sprintf(safe_url + j, "%%%02x", url[i]);


### PR DESCRIPTION
Fixed incorrect encoding of '=' when redirecting from http > https
