### PR TITLE
XSRF Redirect encoding fix - do not encode '-' characters

### DIFF
--- a/http.c
+++ b/http.c
@@ -73,7 +73,7 @@ redirect_reply(BIO *const c, const char *url, const int code)
     memset(safe_url, 0, MAXBUF);
     for(i = j = 0; i < MAXBUF && j < MAXBUF && url[i]; i++)
         if(isalnum(url[i]) || url[i] == '_' || url[i] == '.' || url[i] == ':' || url[i] == '/'
-        || url[i] == '?' || url[i] == '&' || url[i] == ';' || url[i] == '=')
+        || url[i] == '?' || url[i] == '&' || url[i] == ';' || url[i] == '=' || url[i] == '-')
             safe_url[j++] = url[i];
         else {
             sprintf(safe_url + j, "%%%02x", url[i]);

--- a/poundctl.c
+++ b/poundctl.c
@@ -37,8 +37,8 @@ usage(const char *arg0)
     fprintf(stderr, "\twhere cmd is one of:\n");
     fprintf(stderr, "\t-L n - enable listener n\n");
     fprintf(stderr, "\t-l n - disable listener n\n");
-    fprintf(stderr, "\t-S n m - enable service m in service n (use -1 for global services)\n");
-    fprintf(stderr, "\t-s n m - disable service m in service n (use -1 for global services)\n");
+    fprintf(stderr, "\t-S n m - enable service m in listener n (use -1 for global services)\n");
+    fprintf(stderr, "\t-s n m - disable service m in listener n (use -1 for global services)\n");
     fprintf(stderr, "\t-B n m r - enable back-end r in service m in listener n\n");
     fprintf(stderr, "\t-b n m r - disable back-end r in service m in listener n\n");
     fprintf(stderr, "\t-f n m r - flush all sessions for back-end r in service m in listener n\n");


### PR DESCRIPTION
Small fix to prevent the encoding of '-' (dash) characters in URLs
